### PR TITLE
Remove StringUtils

### DIFF
--- a/src/utils/StringUtils test.ts
+++ b/src/utils/StringUtils test.ts
@@ -1,9 +1,0 @@
-import { containsSubstring } from "./StringUtils";
-
-test('containsSubstring finds needle in haystack', () => {
-    const needle = 'found';
-    const haystack = "I'll never be found";
-    const expected = false;
-
-    expect(containsSubstring(needle, haystack)).toBe(expected);
-});

--- a/src/utils/StringUtils.ts
+++ b/src/utils/StringUtils.ts
@@ -1,3 +1,0 @@
-export function containsSubstring(needle: string, haystack: string) {
-    return haystack.toLocaleLowerCase().includes(needle);
-};


### PR DESCRIPTION
This PR removes the unused `stringUtils.ts` from the project.