### PR TITLE
Add UserContext

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,16 @@ import './App.css';
 import { Container } from 'react-bootstrap';
 import GraphQLApiProvider from './utils/GraphQLApiProvider';
 import Movies from './components/Movies';
+import UserContextProvider from './utils/UserContext';
 
 function App() {
   return (
     <GraphQLApiProvider>
-      <Container>
-        <Movies />
-      </Container>
+      <UserContextProvider>
+        <Container>
+          <Movies />
+        </Container>
+      </UserContextProvider>
     </GraphQLApiProvider>
   );
 }

--- a/src/components/ReviewModal/ReviewForm.tsx
+++ b/src/components/ReviewModal/ReviewForm.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { InputGroup, FormControl, Button } from 'react-bootstrap';
 import { useCreateReviewMutation } from '../../graphqlTypes';
 import ReactStars from 'react-stars';
+import { UserContext } from '../../utils/UserContext';
 
 type Props = {
     id: string;
@@ -9,8 +10,9 @@ type Props = {
 };
 
 const ReviewForm: React.FC<Props> = ({ id, onAfterReview }) => {
+    const { user, setUser } = useContext(UserContext);
     const [rating, setRating] = useState<number>(0);
-    const [reviewer, setReviewer] = useState<string>('');
+    const [reviewer, setReviewer] = useState<string>(user?.name || '');
     const [addReviewForMovieMutation, { loading, error }] = useCreateReviewMutation({ refetchQueries: ['findReviewsByMovieId'] });
 
     const isReviewerEmpty = reviewer.length === 0;
@@ -18,6 +20,7 @@ const ReviewForm: React.FC<Props> = ({ id, onAfterReview }) => {
 
     const handleReview = () => {
         addReviewForMovieMutation({ variables: { input: { imdbID: id, rating, reviewer } } });
+        setUser({ name: reviewer });
         if (!loading){
             if (error) {
                 console.error(error)

--- a/src/utils/UserContext/index.test.tsx
+++ b/src/utils/UserContext/index.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import UserContextProvider from '.';
+
+describe('<UserContextProvider />', () => {
+    test('renders without error', () => {
+        const wrapper = shallow(<UserContextProvider />);
+
+        expect(wrapper.length).toBe(1);
+    });
+});

--- a/src/utils/UserContext/index.tsx
+++ b/src/utils/UserContext/index.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useState } from 'react';
+
+type User = {
+    name: string;
+};
+
+interface UserContext {
+    user?: User;
+    setUser: (user?: User) => void;
+};
+
+export const UserContext = createContext<UserContext>({user: undefined, setUser: () => {}});
+
+type Props = {
+    user?: User;
+};
+
+const UserContextProvider: React.FC<Props> = ({ children, user: initialUser }) => {
+    const [user, setUser] = useState<User | undefined>(initialUser);
+    
+    const contextValue: UserContext = {
+        user,
+        setUser: (user?: User) => { setUser(user) },
+    };
+
+    return (
+        <UserContext.Provider value={contextValue}>
+            {children}
+        </UserContext.Provider>
+    );
+};
+
+export default UserContextProvider;


### PR DESCRIPTION
This PR adds a basic context for managing the user. 

This is definitely overkill at this point in time, but I want to experiment with context in a simple state.

The intention of this is to start on improving the usability of the app by persisting the reviewer's name (the user in this context). This will enable a 'Quick Review'(#10) feature in the future. The user's 'name' can be set when submitting a review. The name entered will be used as the default name on reviews.